### PR TITLE
Make hostname more generic (so it works in more systems)

### DIFF
--- a/lyfetch
+++ b/lyfetch
@@ -12,7 +12,7 @@ PINK='\x1b[1;38;2;245;169;184m'
 WHITE='\x1b[1;97m'
 
 # Sys info
-NAME="$(whoami)@$(hostname)"
+NAME="$(whoami)@$(uname -n)"
 OS=$(awk -F= '$1 == "NAME" {gsub(/"/, "", $2); print $2}' /etc/os-release)
 KERNEL=$(uname -r)
 SHELL=$(basename $SHELL)


### PR DESCRIPTION
Currently, the script uses `hostname` to get the machine's hostname. However, this command may not be present in the user's machine.
This pull request replaces the use of `hostname` with `uname -n`, which most users are more likely to have. While it's not guaranteed `uname` will be present either, it's one of the GNU core utils, which are very commonly used, and is already being used to get the kernel name, so no support is lost.